### PR TITLE
fix(im): 修复连接监听器和路由客户端的元数据传递问题

### DIFF
--- a/core/src/main/java/com/wind/integration/core/constant/WindInternalApiConstants.java
+++ b/core/src/main/java/com/wind/integration/core/constant/WindInternalApiConstants.java
@@ -22,10 +22,10 @@ public final class WindInternalApiConstants {
     /**
      * 内网开放 API 前缀 （不需要验签）
      */
-    public static final String INC_BASIC_API_PREFIX = INC_API_PREFIX + "/basic/";
+    public static final String INC_BASIC_API_PREFIX = INC_API_PREFIX + "/basic";
 
     /**
      * 内网安全 API 前缀 （需要验签）
      */
-    public static final String INC_SECURE_API_PREFIX = INC_API_PREFIX + "/secure/";
+    public static final String INC_SECURE_API_PREFIX = INC_API_PREFIX + "/secure";
 }

--- a/wind-im/src/main/java/com/wind/integration/im/connection/RemoteSocketRouteClientConnection.java
+++ b/wind-im/src/main/java/com/wind/integration/im/connection/RemoteSocketRouteClientConnection.java
@@ -32,7 +32,7 @@ public class RemoteSocketRouteClientConnection implements WindSocketRouteClientC
     private static final ExecutorService EXECUTOR = ExecutorServiceUtils.custom("route-message-sent-", 1, 4, 128);
 
     // TODO 支持端口号配置
-    private static final String REMOTE_NODE_URL_PATTERN = "http://%s:8080%s";
+    private static final String REMOTE_NODE_URL_PATTERN = "http://%s:8080/%s";
 
     private final String remoteNodeAddress;
 
@@ -42,7 +42,7 @@ public class RemoteSocketRouteClientConnection implements WindSocketRouteClientC
 
     private final RestClient restClient;
 
-     RemoteSocketRouteClientConnection(String remoteNodeAddress, String sessionId, Map<String, Object> metadata, RestClient restClient) {
+    RemoteSocketRouteClientConnection(String remoteNodeAddress, String sessionId, Map<String, Object> metadata, RestClient restClient) {
         this.remoteNodeAddress = remoteNodeAddress;
         this.sessionId = sessionId;
         this.metadata = metadata;

--- a/wind-im/src/main/java/com/wind/integration/im/lifecycle/DefaultSocketioConnectListener.java
+++ b/wind-im/src/main/java/com/wind/integration/im/lifecycle/DefaultSocketioConnectListener.java
@@ -46,6 +46,8 @@ public record DefaultSocketioConnectListener(String nodeIpAddress, WindSocketCon
 
             // 2. 填充客户端元数据
             Map<String, Object> metadata = new HashMap<>();
+            metadata.put(WindWebSocketMetadataNames.USER_ID_NAME, client.get(WindWebSocketMetadataNames.USER_ID_NAME));
+            metadata.put(WindImConstants.USERNAME_VARIABLE_NAME, client.get(WindImConstants.USERNAME_VARIABLE_NAME));
             metadata.put(WindWebSocketMetadataNames.CLIENT_ID_NAME, clientId);
             metadata.put(WindWebSocketMetadataNames.CLIENT_DEVICE_TYPE_NAME, deviceType);
             metadata.put(WindWebSocketMetadataNames.GMT_CONNECTED_NAME, LocalDateTime.now());

--- a/wind-im/src/main/java/com/wind/integration/im/model/request/RouteMessageRequest.java
+++ b/wind-im/src/main/java/com/wind/integration/im/model/request/RouteMessageRequest.java
@@ -36,7 +36,7 @@ public record RouteMessageRequest<T>(@NonNull String sessionId,
             @JsonProperty(Fields.payload) T payload,
             @JsonProperty(Fields.receiveUserId) String receiveUserId,
             @JsonProperty(Fields.receiveClientDeviceType) String receiveClientDeviceType,
-            @JsonProperty(Fields.receiveClientDeviceType) Map<String, Object> metadata
+            @JsonProperty(Fields.metadata) Map<String, Object> metadata
     ) {
         this.sessionId = sessionId;
         this.payload = payload;

--- a/wind-im/src/main/java/com/wind/integration/im/session/DefaultWindSocketSession.java
+++ b/wind-im/src/main/java/com/wind/integration/im/session/DefaultWindSocketSession.java
@@ -6,6 +6,7 @@ import com.wind.integration.im.connection.DefaultWindSocketConnectionListener;
 import com.wind.integration.im.connection.ImmutableSocketClientConnectionMetadata;
 import com.wind.integration.im.spi.WindChatSessionService;
 import com.wind.websocket.core.SocketClientConnectionDescriptor;
+import com.wind.websocket.core.WindSessionConnectionPolicy;
 import com.wind.websocket.core.WindSocketClientClientConnection;
 import com.wind.websocket.core.WindSocketClientClientConnectionFactory;
 import com.wind.websocket.core.WindSocketSession;
@@ -400,6 +401,11 @@ public class DefaultWindSocketSession implements WindSocketSession {
     @Override
     public WindSocketSessionStatus getStatus() {
         return sessionDescriptor.getStatus();
+    }
+
+    @Override
+    public @NotNull WindSessionConnectionPolicy getSessionConnectionPolicy() {
+        return sessionDescriptor.getSessionConnectionPolicy();
     }
 
     @Override


### PR DESCRIPTION
- 在 DefaultSocketioConnectListener 中添加用户ID和用户名到元数据映射
- 为 DefaultWindSocketSession 添加会话连接策略获取方法
- 修复 RemoteSocketRouteClientConnection 中远程节点URL模式的路径分隔符
- 修正 RouteMessageRequest 中元数据字段的JSON属性注解
- 移除 WindInternalApiConstants 中API前缀的多余斜杠